### PR TITLE
Makefile: call make with $(MAKE) in case it's not "make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ format: $(all_srcs)
 clean:
 	@rm -rf build/*
 	@rm -rf webui/scripts/*
-	@cd extensions/chrome && make clean
+	@cd extensions/chrome && $(MAKE) clean
 
 chrome-extension: webui-build
-	cd extensions/chrome && make
+	cd extensions/chrome && $(MAKE)
 
 firefox-extension: chrome-extension
 	@$(NODE_BIN_DIR)/web-ext build $(webext_common_args)


### PR DESCRIPTION
On at least OpenBSD, building requires `gmake`, so using `$(MAKE)` when expand to whatever was used to call the initial compilation.